### PR TITLE
Fixed broken link

### DIFF
--- a/DriveSim.md
+++ b/DriveSim.md
@@ -1,6 +1,6 @@
 # Drive Simulator
 Follow the instructions to train a generative model as described by
-[Learning a Driving Simulator]().
+[Learning a Driving Simulator](http://arxiv.org/abs/1608.01230).
 
 1) Download dataset
 ```


### PR DESCRIPTION
Actual link to "Learning a Driving Simulator" was missing. I have added the same link mentioned in README.md
